### PR TITLE
Allow to specify installed Jekyll version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ node default {
 }
 ```
 
+To specify a version (e.g. because Jekyll3 does not support Ruby 1.9.3):
+```puppet
+node default {
+	class {'jekyll':
+    version => '2.5.3'
+  }
+}
+```
+or in Hiera:
+```yml
+jekyll::version: 2.5.3
+```
 Contact
 -------
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ To specify a version (e.g. because Jekyll3 does not support Ruby 1.9.3):
 ```puppet
 node default {
 	class {'jekyll':
-    version => '2.5.3'
-  }
+		version => '2.5.3'
+	}
 }
 ```
 or in Hiera:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,18 +1,19 @@
-class jekyll
-{
+class jekyll (
+  $version = 'latest'
+) {
 	$distPackages = ['python-pygments','build-essential','ruby-dev']
 	package {$distPackages:
 		ensure => present,
 	}
-	
+
 	package {'RedCloth':
 		ensure   => present,
 		provider => gem,
 		require  => [Package['build-essential'], Package['ruby-dev']],
 	}
-	
+
 	package {'jekyll':
-		ensure   => present,
+		ensure   => $version,
 		provider => gem,
 		require  => [Package['python-pygments'], Package['RedCloth']],
 	}


### PR DESCRIPTION
The issue is that v3 does not support Ruby < 2.0.0

Change should be BC
